### PR TITLE
[ADD] 제품 상세페이지 장바구니 담기, 조회 기능 구현

### DIFF
--- a/controllers/cartController.js
+++ b/controllers/cartController.js
@@ -1,0 +1,39 @@
+const cartService = require("../services/cartService");
+
+const postCart = async (req, res) => {
+  try {
+    const { quantity } = req.body;
+    const { productId } = req.params;
+    const userId = req.userId;
+
+    if (!quantity) {
+      return res.status(400).json({ message: "KEY_ERROR" });
+    }
+
+    await cartService.postCart(quantity, productId, userId);
+    return res.status(201).json({
+      message: "CART_ADD_SUCCESS",
+    });
+  } catch (err) {
+    console.log(err);
+    return res.status(err.statusCode || 500).json({ message: err.message });
+  }
+};
+
+const deleteAllCart = async (req, res) => {
+  try {
+    const { productId } = req.params;
+    const userId = req.userId;
+
+    console.log(productId, userId)
+    await cartService.deleteAllCart(productId, userId);
+    return res.status(204).json({
+      message: "CART_DELETE_SUCCESS",
+    });
+  } catch (err) {
+    console.log(err);
+    return res.status(err.statusCode || 500).json({ message: err.message });
+  }
+};
+
+module.exports = { postCart, deleteAllCart };

--- a/controllers/cartController.js
+++ b/controllers/cartController.js
@@ -1,7 +1,6 @@
 const cartService = require("../services/cartService");
 
 const postCart = async (req, res) => {
-  console.log(req.body)
   try {
     const { quantity } = req.body;
     const { productId } = req.params;
@@ -21,4 +20,18 @@ const postCart = async (req, res) => {
   }
 };
 
-module.exports = { postCart };
+const countUserCart = async (req, res) => {
+  try {
+    const userId = req.userId;
+
+    const cartCounting = await cartService.countUserCart(userId);
+    return res.status(200).json({
+      data: cartCounting,
+    });
+  } catch (err) {
+    console.log(err);
+    return res.status(err.statusCode || 500).json({ message: err.message });
+  }
+};
+
+module.exports = { postCart, countUserCart };

--- a/controllers/cartController.js
+++ b/controllers/cartController.js
@@ -1,6 +1,7 @@
 const cartService = require("../services/cartService");
 
 const postCart = async (req, res) => {
+  console.log(req.body)
   try {
     const { quantity } = req.body;
     const { productId } = req.params;
@@ -20,18 +21,4 @@ const postCart = async (req, res) => {
   }
 };
 
-const deleteAllCart = async (req, res) => {
-  try {
-    const userId = req.userId;
-
-    await cartService.deleteAllCart(userId);
-    return res.status(204).json({
-      message: "CART_DELETE_SUCCESS",
-    });
-  } catch (err) {
-    console.log(err);
-    return res.status(err.statusCode || 500).json({ message: err.message });
-  }
-};
-
-module.exports = { postCart, deleteAllCart };
+module.exports = { postCart };

--- a/controllers/cartController.js
+++ b/controllers/cartController.js
@@ -25,7 +25,6 @@ const deleteAllCart = async (req, res) => {
     const { productId } = req.params;
     const userId = req.userId;
 
-    console.log(productId, userId)
     await cartService.deleteAllCart(productId, userId);
     return res.status(204).json({
       message: "CART_DELETE_SUCCESS",

--- a/controllers/cartController.js
+++ b/controllers/cartController.js
@@ -22,10 +22,9 @@ const postCart = async (req, res) => {
 
 const deleteAllCart = async (req, res) => {
   try {
-    const { productId } = req.params;
     const userId = req.userId;
 
-    await cartService.deleteAllCart(productId, userId);
+    await cartService.deleteAllCart(userId);
     return res.status(204).json({
       message: "CART_DELETE_SUCCESS",
     });

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -9,7 +9,7 @@ const validateToken = async (req, res, next) => {
     const accessToken = headers.split(" ")[1];
     const decode = jwt.verify(accessToken, process.env.JWT_SECRET);
     const userId = decode.sub;
-    const user = await authDao.getUserByuserId(userId);
+    const user = await authDao.getUserById(userId);
 
     if (!user) {
       res.status(404).json({ message: "USER_NOT_FOUND" });

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,0 +1,27 @@
+//middlewares/auth.js
+
+const authDao = require("../models/authDao");
+const jwt = require("jsonwebtoken");
+
+const validateToken = async (req, res, next) => {
+  try {
+    const headers = req.headers["authorization"];
+    const accessToken = headers.split(" ")[1];
+    const decode = jwt.verify(accessToken, process.env.JWT_SECRET);
+    const userId = decode.sub;
+    const user = await authDao.getUserByuserId(userId);
+
+    if (!user) {
+      res.status(404).json({ message: "USER_NOT_FOUND" });
+    }else{
+      req.userId = userId;
+      next();
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = {
+  validateToken,
+};

--- a/models/authDao.js
+++ b/models/authDao.js
@@ -2,39 +2,36 @@ const { appDataSource } = require("./dataSource");
 
 const createUser = async (email, password, name) => {
   await appDataSource.query(
-    `
-    INSERT INTO users (
+    `INSERT INTO users (
       email,
       password,
       name
-    ) VALUES (?,?,?)
-    `,
+    ) VALUES (?,?,?)`,
     [email, password, name]
   );
 };
 
 const getUserByEmail = async (email) => {
   const [user] = await appDataSource.query(
-    `
-      SELECT *
-      FROM users u
-      WHERE u.email = ?
-    `,
+    `SELECT *
+     FROM users u
+     WHERE u.email = ?`,
+
     [email]
   );
 
   return user;
 };
 
-const getUserByuserId = async (userId) => {
+const getUserById = async (id) => {
   const [user] = await appDataSource.query(
     `SELECT *
-     FROM users
-     WHERE id = ?`,
-    [userId]
+     FROM users u
+     WHERE u.id = ?
+    `,
+    [id]
   );
-
   return user;
 };
 
-module.exports = { createUser, getUserByEmail, getUserByuserId };
+module.exports = { createUser, getUserByEmail, getUserById };

--- a/models/authDao.js
+++ b/models/authDao.js
@@ -26,4 +26,15 @@ const getUserByEmail = async (email) => {
   return user;
 };
 
-module.exports = { createUser, getUserByEmail };
+const getUserByuserId = async (userId) => {
+  const [user] = await appDataSource.query(
+    `SELECT *
+     FROM users
+     WHERE id = ?`,
+    [userId]
+  );
+
+  return user;
+};
+
+module.exports = { createUser, getUserByEmail, getUserByuserId };

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -1,14 +1,24 @@
-const app = require("hostman/src/web/app");
 const { appDataSource } = require("./dataSource");
 
 const existProduct = async (productId) => {
   const [product] = await appDataSource.query(
     `SELECT *
      FROM products
-     WHERE id = ${productId}`
+     WHERE id = ${productId}`,
   );
 
   return product;
+};
+
+const checkStock = async (productId) => {
+  const [stock] = await appDataSource.query(
+    `SELECT
+      stock
+     FROM products
+     WHERE id = ${productId}`,
+  );
+
+  return parseInt(Object.values(stock));
 };
 
 const existCart = async (productId, userId) => {
@@ -74,4 +84,5 @@ module.exports = {
   existCart,
   updateCart,
   deleteAllCart,
+  checkStock
 };

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -1,0 +1,78 @@
+const app = require("hostman/src/web/app");
+const { appDataSource } = require("./dataSource");
+
+const existProduct = async (productId) => {
+  const [product] = await appDataSource.query(
+    `SELECT *
+     FROM products
+     WHERE id = ${productId}`
+  );
+
+  return product;
+};
+
+const existCart = async (productId, userId) => {
+  const [existCartPd] = await appDataSource.query(
+    `SELECT count(*)
+     FROM carts
+     WHERE product_id = ${productId}
+     AND user_id = ${userId}`
+  );
+
+  return parseInt(Object.values(existCartPd)[0]);
+};
+
+const postCart = async (quantity, productId, userId) => {
+  try {
+    return await appDataSource.query(
+      `INSERT INTO carts(
+            quantity, 
+            product_id, 
+            user_id
+         ) VALUES (?, ?, ?)`,
+
+      [quantity, productId, userId]
+    );
+  } catch (err) {
+    const error = new Error("PRODUCT_DOES_NOT_EXIST");
+    error.statusCode = 400;
+    throw error;
+  }
+};
+
+const updateCart = async (quantity, productId, userId) => {
+  try {
+    return await appDataSource.query(
+      `UPDATE carts 
+       SET quantity = quantity + ${quantity}
+       WHERE product_id = ${productId} 
+       AND user_id = ${userId}`
+    );
+  } catch (err) {
+    const error = new Error("PRODUCT_DOES_NOT_EXIST");
+    error.statusCode = 400;
+    throw error;
+  }
+};
+
+const deleteAllCart = async (productId, userId) => {
+  try {
+    return await appDataSource.query(
+      `DELETE FROM
+        carts
+       WHERE product_id = ${productId}
+       AND user_id = ${userId}`
+    );
+  } catch (err) {
+    const error = new Error("PRODUCT_DOES_NOT_EXIST");
+    error.statusCode = 400;
+    throw error;
+  }
+};
+module.exports = {
+  existProduct,
+  postCart,
+  existCart,
+  updateCart,
+  deleteAllCart,
+};

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -55,16 +55,15 @@ const updateCart = async (quantity, productId, userId) => {
   }
 };
 
-const deleteAllCart = async (productId, userId) => {
+const deleteAllCart = async (userId) => {
   try {
     return await appDataSource.query(
       `DELETE FROM
         carts
-       WHERE product_id = ${productId}
-       AND user_id = ${userId}`
+       WHERE user_id = ${userId}`
     );
   } catch (err) {
-    const error = new Error("PRODUCT_DOES_NOT_EXIST");
+    const error = new Error("USER_DOES_NOT_EXIST");
     error.statusCode = 400;
     throw error;
   }

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -65,20 +65,6 @@ const updateCart = async (quantity, productId, userId) => {
   }
 };
 
-const deleteAllCart = async (userId) => {
-  try {
-    return await appDataSource.query(
-      `DELETE FROM
-        carts
-       WHERE user_id = ${userId}`
-    );
-  } catch (err) {
-    const error = new Error("USER_DOES_NOT_EXIST");
-    error.statusCode = 400;
-    throw error;
-  }
-};
-
 const countUserCart = async (userId) => {
   const [cartCounting] = await appDataSource.query(
     `SELECT 
@@ -95,7 +81,6 @@ module.exports = {
   postCart,
   existCart,
   updateCart,
-  deleteAllCart,
   checkStock,
   countUserCart,
 };

--- a/models/cartDao.js
+++ b/models/cartDao.js
@@ -4,7 +4,7 @@ const existProduct = async (productId) => {
   const [product] = await appDataSource.query(
     `SELECT *
      FROM products
-     WHERE id = ${productId}`,
+     WHERE id = ${productId}`
   );
 
   return product;
@@ -15,7 +15,7 @@ const checkStock = async (productId) => {
     `SELECT
       stock
      FROM products
-     WHERE id = ${productId}`,
+     WHERE id = ${productId}`
   );
 
   return parseInt(Object.values(stock));
@@ -78,11 +78,24 @@ const deleteAllCart = async (userId) => {
     throw error;
   }
 };
+
+const countUserCart = async (userId) => {
+  const [cartCounting] = await appDataSource.query(
+    `SELECT 
+        COUNT(*) 
+       FROM carts
+       WHERE user_id = ${userId}`
+  );
+
+  return parseInt(Object.values(cartCounting));
+};
+
 module.exports = {
   existProduct,
   postCart,
   existCart,
   updateCart,
   deleteAllCart,
-  checkStock
+  checkStock,
+  countUserCart,
 };

--- a/routes/cartRouter.js
+++ b/routes/cartRouter.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const cartController = require("../controllers/cartController");
+const auth = require("../middlewares/auth");
+
+const router = express.Router();
+
+router.post("/cart/:productId", auth.validateToken, cartController.postCart);
+router.delete("/cart/:productId", auth.validateToken, cartController.deleteAllCart);
+
+module.exports = {
+    router
+}

--- a/routes/cartRouter.js
+++ b/routes/cartRouter.js
@@ -4,8 +4,8 @@ const auth = require("../middlewares/auth");
 
 const router = express.Router();
 
-router.post("/cart/:productId", auth.validateToken, cartController.postCart);
-router.delete("/cart/:productId", auth.validateToken, cartController.deleteAllCart);
+router.post("/product/:productId", auth.validateToken, cartController.postCart);
+router.delete("/product/:productId", auth.validateToken, cartController.deleteAllCart);
 
 module.exports = {
     router

--- a/routes/cartRouter.js
+++ b/routes/cartRouter.js
@@ -5,6 +5,7 @@ const auth = require("../middlewares/auth");
 const router = express.Router();
 
 router.post("/product/:productId", auth.validateToken, cartController.postCart);
+router.get("/counting", auth.validateToken, cartController.countUserCart);
 
 module.exports = {
     router

--- a/routes/cartRouter.js
+++ b/routes/cartRouter.js
@@ -5,7 +5,6 @@ const auth = require("../middlewares/auth");
 const router = express.Router();
 
 router.post("/product/:productId", auth.validateToken, cartController.postCart);
-router.delete("/product/:productId", auth.validateToken, cartController.deleteAllCart);
 
 module.exports = {
     router

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,10 @@
 const express = require("express");
-
-const {authRouter} = require("./authRouter");
-
 const router = express.Router();
 
+const {authRouter} = require("./authRouter");
+const cartRouter = require("./cartRouter");
+
 router.use("/auth", authRouter);
+router.use("/user", cartRouter.router);
 
 module.exports = router;
-

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,6 +5,6 @@ const {authRouter} = require("./authRouter");
 const cartRouter = require("./cartRouter");
 
 router.use("/auth", authRouter);
-router.use("/user", cartRouter.router);
+router.use("/cart", cartRouter.router);
 
 module.exports = router;

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -1,0 +1,68 @@
+const cartDao = require("../models/cartDao");
+const { validateQuantity, validateproductId } = require("../utils/validation");
+
+const postCart = async (quantity, productId, userId) => {
+  //validateproductId(productId);
+  validateQuantity(quantity);
+
+  const existProduct = await cartDao.existProduct(productId);
+  const checkCart = await cartDao.existCart(productId, userId);
+
+  console.log(existProduct, checkCart)
+
+  if (!existProduct) {
+    const err = new Error("PRODUCT_DOES_NOT_EXIST");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  if (checkCart === 0) {
+    const postCart = await cartDao.postCart(quantity, productId, userId);
+
+    return postCart;
+  } else if (checkCart > 0) {
+    const updateCart = await cartDao.updateCart(quantity, productId, userId);
+
+    return updateCart;
+  }
+
+  if (quantity === 0) {
+    const err = new Error("QUANTITY_CANNOT_BE_ZERO");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const cartPostOnebyone = async (quantity, productId, userId) => {
+  //validateproductId(productId);
+
+  const existProduct = await cartDao.existProduct(productId);
+
+  if (!existProduct) {
+    const err = new Error("PRODUCT_DOES_NOT_EXIST");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const cartOnebyone = await cartDao.cartOnebyone(quantity, productId, userId);
+
+  return cartOnebyone;
+}
+
+const deleteAllCart = async (productId, userId) => {
+  //validateproductId(productId);
+
+  const existProduct = await cartDao.existProduct(productId);
+
+  if (!existProduct) {
+    const err = new Error("PRODUCT_DOES_NOT_EXIST");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const deleteAllCart = await cartDao.deleteAllCart(productId, userId);
+
+  return deleteAllCart;
+};
+
+module.exports = { postCart, deleteAllCart, cartPostOnebyone };

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -3,11 +3,13 @@ const authDao = require("../models/authDao");
 const { validateQuantity, validateproductId } = require("../utils/validation");
 
 const postCart = async (quantity, productId, userId) => {
+  console.log(quantity, productId, userId)
   validateproductId(productId);
   validateQuantity(quantity);
 
   const existProduct = await cartDao.existProduct(productId);
   const checkCart = await cartDao.existCart(productId, userId);
+  const checkStock = await cartDao.checkStock(productId);
 
   if (!existProduct) {
     const err = new Error("PRODUCT_DOES_NOT_EXIST");
@@ -15,35 +17,28 @@ const postCart = async (quantity, productId, userId) => {
     throw err;
   }
 
-  if (checkCart === 0) {
-    const postCart = await cartDao.postCart(quantity, productId, userId);
-
-    return postCart;
-  } else if (checkCart > 0) {
-    const updateCart = await cartDao.updateCart(quantity, productId, userId);
-
-    return updateCart;
-  }
-
-  if (quantity === 0) {
+  if (quantity == 0) {
     const err = new Error("QUANTITY_CANNOT_BE_ZERO");
     err.statusCode = 400;
     throw err;
   }
-};
 
-const deleteAllCart = async (userId) => {
-  const user = await authDao.getUserByuserId(userId);
+  if(quantity <= checkStock) {
 
-  if (!user) {
-    const err = new Error("USER_DOES_NOT_EXIST");
-    err.statusCode = 404;
+    if (checkCart === 0) {
+      const postCart = await cartDao.postCart(quantity, productId, userId);
+  
+      return postCart;
+    } else if (checkCart > 0) {
+      const updateCart = await cartDao.updateCart(quantity, productId, userId);
+  
+      return updateCart;
+    }
+  } else {
+    const err = new Error("CANNOT_ORDER_QUANTITY_LARGER_THAN_STOCK");
+    err.statusCode = 401;
     throw err;
   }
-
-  const deleteAllCart = await cartDao.deleteAllCart(userId);
-
-  return deleteAllCart;
 };
 
-module.exports = { postCart, deleteAllCart };
+module.exports = { postCart };

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -35,7 +35,7 @@ const postCart = async (quantity, productId, userId) => {
     }
   } else {
     const err = new Error("CANNOT_ORDER_QUANTITY_LARGER_THAN_STOCK");
-    err.statusCode = 401;
+    err.statusCode = 400;
     throw err;
   }
 };

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -1,8 +1,9 @@
 const cartDao = require("../models/cartDao");
+const authDao = require("../models/authDao");
 const { validateQuantity, validateproductId } = require("../utils/validation");
 
 const postCart = async (quantity, productId, userId) => {
-  //validateproductId(productId);
+  validateproductId(productId);
   validateQuantity(quantity);
 
   const existProduct = await cartDao.existProduct(productId);
@@ -31,36 +32,18 @@ const postCart = async (quantity, productId, userId) => {
   }
 };
 
-const cartPostOnebyone = async (quantity, productId, userId) => {
-  //validateproductId(productId);
+const deleteAllCart = async (userId) => {
+  const user = await authDao.getUserByuserId(userId);
 
-  const existProduct = await cartDao.existProduct(productId);
-
-  if (!existProduct) {
-    const err = new Error("PRODUCT_DOES_NOT_EXIST");
+  if (!user) {
+    const err = new Error("USER_DOES_NOT_EXIST");
     err.statusCode = 404;
     throw err;
   }
 
-  const cartOnebyone = await cartDao.cartOnebyone(quantity, productId, userId);
-
-  return cartOnebyone;
-}
-
-const deleteAllCart = async (productId, userId) => {
-  //validateproductId(productId);
-
-  const existProduct = await cartDao.existProduct(productId);
-
-  if (!existProduct) {
-    const err = new Error("PRODUCT_DOES_NOT_EXIST");
-    err.statusCode = 404;
-    throw err;
-  }
-
-  const deleteAllCart = await cartDao.deleteAllCart(productId, userId);
+  const deleteAllCart = await cartDao.deleteAllCart(userId);
 
   return deleteAllCart;
 };
 
-module.exports = { postCart, deleteAllCart, cartPostOnebyone };
+module.exports = { postCart, deleteAllCart };

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -8,8 +8,6 @@ const postCart = async (quantity, productId, userId) => {
   const existProduct = await cartDao.existProduct(productId);
   const checkCart = await cartDao.existCart(productId, userId);
 
-  console.log(existProduct, checkCart)
-
   if (!existProduct) {
     const err = new Error("PRODUCT_DOES_NOT_EXIST");
     err.statusCode = 404;

--- a/services/cartService.js
+++ b/services/cartService.js
@@ -3,7 +3,6 @@ const authDao = require("../models/authDao");
 const { validateQuantity, validateproductId } = require("../utils/validation");
 
 const postCart = async (quantity, productId, userId) => {
-  console.log(quantity, productId, userId)
   validateproductId(productId);
   validateQuantity(quantity);
 
@@ -41,4 +40,10 @@ const postCart = async (quantity, productId, userId) => {
   }
 };
 
-module.exports = { postCart };
+const countUserCart = async (userId) => {
+  const cartCounting = await cartDao.countUserCart(userId);
+
+  return cartCounting;
+};
+
+module.exports = { postCart, countUserCart };

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -21,6 +21,15 @@ const validatePw = (password) => {
   }
 };
 
+const validateproductId = (productId) => {
+  const pdIdValidation = new RegExp(/^\d+$/);
+  if (!pdIdValidation.test(productId)) {
+    const err = new Error("INVALID_PRODUCT_ID");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
 const validateQuantity = (quantity) => {
   const quantityValidation = new RegExp(/^\d+$/);
   
@@ -31,4 +40,4 @@ const validateQuantity = (quantity) => {
   }
 };
 
-module.exports = { validateEmail, validatePw, validateQuantity };
+module.exports = { validateEmail, validatePw, validateQuantity, validateproductId };

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,21 +1,34 @@
 const validateEmail = (email) => {
-    const emValidation = new RegExp(
-        /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/
-    );
-    if(!emValidation.test(email)){
-        const err = new Error("INVAILD_EMAIL")
-        err.statusCode = 400;
-        throw err;
-        }}
+  const emValidation = new RegExp(
+    /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/
+  );
+  if (!emValidation.test(email)) {
+    const err = new Error("INVAILD_EMAIL");
+    err.statusCode = 400;
+    throw err;
+  }
+};
 
 const validatePw = (password) => {
-    const pwValidation = new RegExp(
-        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{6,16}$/
-    );
-    
-    if (!pwValidation.test(password)) {
-        const err = new Error("INVAILD_PASSWORD");
-        err.statusCode = 400;
-        throw err;}};
-      
-module.exports = {validateEmail, validatePw};  
+  const pwValidation = new RegExp(
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{6,16}$/
+  );
+
+  if (!pwValidation.test(password)) {
+    const err = new Error("INVAILD_PASSWORD");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const validateQuantity = (quantity) => {
+  const quantityValidation = new RegExp(/^\d+$/);
+  
+  if (!quantityValidation.test(quantity)) {
+    const err = new Error("INVALID_QUANTITY");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+module.exports = { validateEmail, validatePw, validateQuantity };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 상세 페이지 내 장바구니 담기, 유저의 장바구니 내 상품 갯수 조회 기능

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 제품 상세페이지 내 장바구니 담기
- 입력되는 값을 유효성 검사 후 통과하지 못 할 경우 에러 메시지를 반환 예외 처리 구현
- 재고보다 요청값이 크게 될 경우 에러 메시지를 반환 예외 처리 구현
- 장바구니에 요청값과 상품 아이디를 DB에 INSERT 구현
- 존재하는 상품일 경우 quantity만을 DB에 UPDATE 구현

2. 유저의 장바구니 갯수 조회
- jwt를 복호화하여 유저 Id에 따라 장바구니에 담긴 상품의 갯수를 반환하는 기능 구현 (상단바 뱃지용) 

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 이미 장바구니에 존재하는 상품에 대한 수량을 늘리는 로직을 이해하게 되었다.

<br />