### PR TITLE
상품 조회 기능 보완(트랜잭션 이용하여 페이지네이션 할때 상품의 총개수도 보내기)

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -14,7 +14,7 @@ const productList = async (req, res) => {
     
         const list = await productService.productList(page, pageSize, cate, orderBy)
         
-        res.status(200).json({data: list})
+        res.status(200).json({products: list[0], count : list[1]})
         }
     catch (err) {console.log(err);
         return res.status(err.statusCode || 500).json({ message: err.message });

--- a/services/productService.js
+++ b/services/productService.js
@@ -15,7 +15,8 @@ const productList = async (page, pageSize, cate, orderBy) => {
         start = (page - 1) * pageSize;
       }
     const getOrderByList = await productDao.getOrderByList(start, pageSize, cate, orderBy)
-      return getOrderByList
+      
+    return getOrderByList
     }
 
 const productSearch = async (word) => {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 아이디, 비밀번호 입력창을 사용한 로그인 기능 구현 (예시)

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
말그대로 트랜잭션을 이용하여
상품을 페이지네이션 할때 상품의 총개수도 동시에 보낼 수 있도록 조정하였습니다.

<br />



<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
